### PR TITLE
chore: reduce image size and vulnerabilities

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN yarn
 RUN yarn build
 
-FROM node:18 as run
+FROM node:18.10-alpine as run
 
 RUN mkdir /app
 COPY --from=build /build /app/build


### PR DESCRIPTION
## イメージサイズ
Before: 1.14GB
After: 312MB

## 脆弱性
Before:
![image](https://user-images.githubusercontent.com/37594486/193233517-84f0aa0e-21ef-42ce-a8f4-7e3bc0c80bfa.png)

After:
![image](https://user-images.githubusercontent.com/37594486/193233581-15370997-06c0-4a3d-94c3-12549d35ad90.png)
